### PR TITLE
Overload of some Vector3D operators

### DIFF
--- a/HappieEngine/Vector3D.cpp
+++ b/HappieEngine/Vector3D.cpp
@@ -38,3 +38,37 @@ Vector3D& Vector3D::operator=(const Vector3D& rhs){
 
 	return *this;
 }
+
+Vector3D operator+(const Vector3D& lhs, const Vector3D& rhs) {
+	Vector3D sum = Vector3D();
+
+	sum.x = lhs.x + rhs.x;
+	sum.y = lhs.y + rhs.y;
+	sum.z = lhs.z + rhs.z;
+
+	return sum;
+}
+
+Vector3D operator-(const Vector3D& lhs, const Vector3D& rhs) {
+	Vector3D diff = Vector3D();
+
+	diff.x = lhs.x - rhs.x;
+	diff.y = lhs.y - rhs.y;
+	diff.z = lhs.z - rhs.z;
+
+	return diff;
+}
+
+Vector3D operator*(const Vector3D& lhs, const float& rhs) {
+	Vector3D mul = Vector3D();
+
+	mul.x = lhs.x * rhs;
+	mul.y = lhs.y * rhs;
+	mul.z = lhs.z * rhs;
+
+	return mul;	
+}
+
+Vector3D operator*(const float& lhs, const Vector3D& rhs) {
+	return rhs * lhs;
+}

--- a/HappieEngine/Vector3D.h
+++ b/HappieEngine/Vector3D.h
@@ -13,6 +13,11 @@ public:
 	Vector3D(const Vector3D& v);
 	Vector3D& operator= (const Vector3D& rhs);
 
+	friend Vector3D operator+(const Vector3D& lhs, const Vector3D& rhs);
+	friend Vector3D operator-(const Vector3D& lhs, const Vector3D& rhs);
+	friend Vector3D operator*(const Vector3D& lhs, const float& rhs);
+	friend Vector3D operator*(const float& lhs, const Vector3D& rhs);
+		
 private:
 
 };


### PR DESCRIPTION
Overload of:
- const Vector3D& + const Vector3D&
- const Vector3D& - const Vector3D& 
- const Vector3D& * const float&
- const float& * const Vector3D&

// I'm a new subscribe and I didn't notice that this was a repo of 2 year ago.
// But i'm glad to help.